### PR TITLE
add ENsaveinpfile method

### DIFF
--- a/wntr/epanet/toolkit.py
+++ b/wntr/epanet/toolkit.py
@@ -440,3 +440,20 @@ class ENepanet():
         return fValue.value
 
 
+    def ENsaveinpfile(self, inpfile):
+        """
+        Saves EPANET input file
+
+        Arguments:
+         * inpfile = EPANET .inp output file
+
+        """
+
+        inpfile = inpfile.encode('ascii')
+        self.errcode = self.ENlib.ENsaveinpfile(inpfile)
+        self._error()
+
+        return
+
+
+    


### PR DESCRIPTION
This just adds access to the existing epanet toolkit method of same name. We use this to process and ‘standardize’ epanet input files after various changes are made, so that differences can be identified easily.